### PR TITLE
add inference node for gradio pod

### DIFF
--- a/template/crd-inference.yaml
+++ b/template/crd-inference.yaml
@@ -17,6 +17,8 @@ spec:
   inactiveAfterSeconds: 0
   recycleAfterSeconds: {{.RecycleSeconds}}
   restartPolicy: Never
+  nodeSelector:
+    inference: "true"
   resources:
     requests:
       cpu: "{{.CPU}}"


### PR DESCRIPTION
1. gradio pod目前与jupyter节点共享的。（与k8s的调度有关）
2. 对gradio pod新增了一个标签，inference，节点规格为32U64G，若一个pod需要2u4G，预测可有15个左右的pod